### PR TITLE
Fixed Point of Sale START requests

### DIFF
--- a/src/Requests/StartRequest.php
+++ b/src/Requests/StartRequest.php
@@ -38,6 +38,7 @@ class StartRequest extends Request
         $classnameElements = explode('\\', $classname);
         $paymentMethod = lcfirst(array_pop($classnameElements));
 
+        $paymentMethodArr = [];
 
         switch ($paymentMethod) {
             case 'amexPaymentInput':


### PR DESCRIPTION
Fixed bug where '$paymentMethodArr' would be unknown during addPaymentMethodData call on StartRequest for Point of Sale.